### PR TITLE
update link to nem-cli repository

### DIFF
--- a/pages/12.dev-tools/docs.en.md
+++ b/pages/12.dev-tools/docs.en.md
@@ -7,8 +7,8 @@ taxonomy:
 
 ##### NEM Modules (Java)
 [plugin:embed](https://github.com/NemProject/nem.modules)
-##### nem-utils (Javascript)
-[plugin:embed](https://github.com/evias/nem-utils)
+##### nem-cli (Node.js)
+[plugin:embed](https://github.com/evias/nem-cli)
 ##### nem-apps (Java)
 [plugin:embed](https://github.com/NEMChina/nem-apps)
 ##### NEMTools (PHP)


### PR DESCRIPTION
Previous name `nem-utils` abandoned to provide with a command line tools suite instead. (first version including a NIS API wrapper)