### PR TITLE
Update docs.en.md

### DIFF
--- a/pages/12.nem-sdk/10.nem-sdk-apostille/docs.en.md
+++ b/pages/12.nem-sdk/10.nem-sdk-apostille/docs.en.md
@@ -29,7 +29,7 @@ var common = nem.model.objects.create("common")("", "privateKey");
 var fileContent = nem.crypto.js.enc.Utf8.parse('Apostille is awesome !');
 
 // Create the Apostille
-var apostille = nem.model.apostille.create(common, "Test.txt", fileContent, "Test Apostille", nem.model.apostille.hashing["SHA256"], false, true, nem.model.network.data.testnet.id);
+var apostille = nem.model.apostille.create(common, "Test.txt", fileContent, "Test Apostille", nem.model.apostille.hashing["SHA256"], false, {}, true, nem.model.network.data.testnet.id);
 
 // Serialize transfer transaction and announce
 nem.model.transactions.send(common, apostille.transaction, endpoint).then(...)


### PR DESCRIPTION
nem.model.apostille.create needs the multisig object even if it is empty